### PR TITLE
Add scripts for manipulating X11 clipboard from command line

### DIFF
--- a/helper_tools/x-copy-files.sh
+++ b/helper_tools/x-copy-files.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copy or cut the specified file names to the clipboard, like a GUI file manager would do.
+# You need to have https://jqlang.org installed.
+# Usage:
+#   x-copy-files copy FILE...
+#   x-copy-files cut FILE...
+# Examples:
+#   x-copy-files copy a.txt
+#   x-copy-files cut 0.png 1.png
+#   alias xcopy='x-copy-files copy' xcut='x-copy-files cut'
+
+set -euo pipefail
+action=${1?'the first argument must be `copy` or `cut`'}
+shift
+{
+    printf '%s\n' "$action"
+    realpath -e -- "$@" | jq -Rr '"file://\(split("/") | map(@uri) | join("/"))"'
+} | xclip -sel clip -t x-special/gnome-copied-files

--- a/helper_tools/x-paste-files.sh
+++ b/helper_tools/x-paste-files.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Paste files from the clipboard, like a GUI file manager would do.
+# Command-line options are forwarded to `cp` or `mv`.
+# Usage:
+#   x-paste-files [options] [TARGET]
+# Examples:
+#   x-paste-files
+#   x-paste-files ~
+#   x-paste-files subdir/ -f
+
+set -euo pipefail
+xclip -o -sel clip -t x-special/gnome-copied-files | (
+    read -r action
+    case $action in
+        copy) action='cp';;
+        cut)  action='mv';;
+        *)    exit 1;;
+    esac
+
+    while read -r f; [[ "$f" ]]; do
+        f=${f#file://}
+        printf -v f %b "${f//%/\\x}"
+        files+=("$f")
+    done
+
+    [[ $# -eq 0 ]] && set .
+    exec "$action" -i "${files[@]}" "$@"
+)


### PR DESCRIPTION
I wrote these simple scripts to assist `clip_share` because I don’t use a graphical file manager. Sharing them in the hope somebody else may find them useful as well.

`x-copy-files` uses [jq](https://jqlang.org): as far as I know, it’s the easiest way to URL-encode strings in Bash.