### PR TITLE
Make compatible with Android 13-

### DIFF
--- a/helper_tools/keygen.sh
+++ b/helper_tools/keygen.sh
@@ -2,6 +2,10 @@
 
 SERVER_NAME='clipshare_server'
 CLIENT_NAME='clipshare_client'
+CLIENT_COMPAT_FLAGS=(
+    # Uncomment for Android <=13:
+    # -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES
+)
 
 set -e
 
@@ -25,10 +29,11 @@ fi
 
 create_encrypted_pfx() {
     local name="$1"
+    shift
     if type winpty &>/dev/null; then
-        winpty openssl pkcs12 -export -in "${name}.crt" -inkey "${name}.key" -out "${name}.pfx"
+        winpty openssl pkcs12 -export -in "${name}.crt" -inkey "${name}.key" -out "${name}.pfx" "$@"
     else
-        openssl pkcs12 -export -in "${name}.crt" -inkey "${name}.key" -out "${name}.pfx"
+        openssl pkcs12 -export -in "${name}.crt" -inkey "${name}.key" -out "${name}.pfx" "$@"
     fi
 }
 
@@ -112,7 +117,7 @@ if [ "$skip_client" = 0 ]; then
     echo 'Exporting client keys ...'
     echo 'Please enter a password that you can remember. You will need this password when importing the key on the client.'
     echo
-    create_encrypted_pfx client
+    create_encrypted_pfx client "${CLIENT_COMPAT_FLAGS[@]}"
     echo
     echo 'Exported client keys.'
 fi


### PR DESCRIPTION
When one tries to import `client.pfx` on Android 13 or below, a toast reading _Invalid client certificate_ is shown. This is apparently caused by an outdated OpenSSL lib that doesn’t support modern encryption algorithms.

With the proposed patch, ClipShare works fine on systems as old as Android 9 (= min SDK).

[openssl-pkcs12](https://docs.openssl.org/3.6/man1/openssl-pkcs12/#notes):
> The **-keypbe** and **-certpbe** algorithms allow the precise encryption algorithms for private keys and certificates to be specified. Normally the defaults are fine but occasionally software can't handle triple DES encrypted private keys, then the option **-keypbe** _PBE-SHA1-RC2-40_ can be used to reduce the private key encryption to 40 bit RC2. A complete description of all algorithms is contained in _openssl-pkcs8(1)_.

[openssl-pkcs8](https://docs.openssl.org/3.6/man1/openssl-pkcs8/#pkcs5-v15-and-pkcs12-algorithms):
> * **PBE-SHA1-RC4-128**, **PBE-SHA1-RC4-40**, **PBE-SHA1-3DES**, **PBE-SHA1-2DES**, **PBE-SHA1-RC2-128**, **PBE-SHA1-RC2-40**
>
> These algorithms use the PKCS#12 password based encryption algorithm and allow strong encryption algorithms like triple DES or 128 bit RC2 to be used.

Unfortunately, I don’t speak PowerShell (yet). Could you adapt `keygen.ps1` yourself please?