### PR TITLE
Suggest another Android-compat workaround

### DIFF
--- a/helper_tools/keygen.sh
+++ b/helper_tools/keygen.sh
@@ -5,6 +5,9 @@ CLIENT_NAME='clipshare_client'
 CLIENT_COMPAT_FLAGS=(
     # Uncomment for Android <=13:
     # -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES
+
+    # If the line above doesn't help, use this instead:
+    # -legacy
 )
 
 set -e


### PR DESCRIPTION
Some time ago, I attempted to use ClipShare on one Android-11-based ROM and was getting the same error as [previously]. I tried various algorithms recommended in the OpenSSL docs, but none worked. However, [legacy mode] helped (this flag alone).

> In the legacy mode, the default algorithm for certificate encryption is RC2_CBC or 3DES_CBC depending on whether the RC2 cipher is enabled in the build. The default algorithm for private key encryption is 3DES_CBC.

Mentioned it as the last resort.

[previously]: https://github.com/thevindu-w/clip_share_server/pull/48
[legacy mode]: https://docs.openssl.org/3.6/man1/openssl-pkcs12/